### PR TITLE
Fix zero feature count display in layer summaries

### DIFF
--- a/cli/arcgispro_cli/commands/inspect.py
+++ b/cli/arcgispro_cli/commands/inspect.py
@@ -110,7 +110,8 @@ def inspect_cmd(path, no_suggestions):
         for layer in layers[:15]:  # Limit to first 15
             visible = "✓" if layer.get("isVisible") else "✗"
             broken = " [red]⚠[/red]" if layer.get("isBroken") else ""
-            features = f"{layer.get('featureCount', '-'):,}" if layer.get('featureCount') else "-"
+            feature_count = layer.get("featureCount")
+            features = f"{feature_count:,}" if feature_count is not None else "-"
             
             table.add_row(
                 f"{layer.get('name', 'Unknown')}{broken}",

--- a/cli/arcgispro_cli/commands/query.py
+++ b/cli/arcgispro_cli/commands/query.py
@@ -177,7 +177,8 @@ def layers_cmd(path, map_name, broken, as_json):
     for layer in layers:
         visible = "✓" if layer.get("isVisible") else ""
         broken_mark = " ⚠" if layer.get("isBroken") else ""
-        features = f"{layer.get('featureCount', '-'):,}" if layer.get('featureCount') else "-"
+        feature_count = layer.get("featureCount")
+        features = f"{feature_count:,}" if feature_count is not None else "-"
         
         table.add_row(
             f"{layer.get('name', 'Unknown')}{broken_mark}",


### PR DESCRIPTION
### Motivation
- Ensure layers with an explicit `0` feature count are shown as `0` instead of `-` by distinguishing `None` from falsy values.

### Description
- Update display logic in `cli/arcgispro_cli/commands/query.py` and `cli/arcgispro_cli/commands/inspect.py` to use `feature_count = layer.get("featureCount")` and format with `f"{feature_count:,}"` when `feature_count is not None`, otherwise show `"-"`.

### Testing
- No automated tests were run for this change; the edits are limited to presentation logic in two CLI output locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985627bc0bc8327bc043ce57b8a422a)