### PR TITLE
feat(tui): ASCII banner + --no-banner

### DIFF
--- a/cli/arcgispro_cli/commands/tui.py
+++ b/cli/arcgispro_cli/commands/tui.py
@@ -8,7 +8,8 @@ def tui():
 
 @tui.command("run", help="Start the ArcGIS Pro TUI")
 @click.option("--repo", default=".", help="Working directory (optional)")
-def run(repo: str) -> None:
+@click.option("--no-banner", is_flag=True, help="Disable the ASCII banner")
+def run(repo: str, no_banner: bool) -> None:
     from arcgispro_cli.tui.app import ArcGISProCLIApp
 
-    ArcGISProCLIApp(repo_path=repo).run()
+    ArcGISProCLIApp(repo_path=repo, show_banner=(not no_banner)).run()

--- a/cli/arcgispro_cli/tui/app.py
+++ b/cli/arcgispro_cli/tui/app.py
@@ -4,6 +4,7 @@ from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Header, Footer
 
+from arcgispro_cli.tui.banner import Banner
 from arcgispro_cli.tui.panels.project_tree import ProjectTree
 from arcgispro_cli.tui.panels.detail_panel import DetailPanel
 from arcgispro_cli.tui.panels.log_panel import LogPanel
@@ -20,12 +21,14 @@ class ArcGISProCLIApp(App):
         ("q", "quit", "Quit"),
     ]
 
-    def __init__(self, repo_path: str = ".", **kwargs):
+    def __init__(self, repo_path: str = ".", *, show_banner: bool = True, **kwargs):
         super().__init__(**kwargs)
         self.state = TUIState(repo_path=repo_path)
+        self.show_banner = show_banner
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
+        yield Banner(enabled=self.show_banner, id="banner")
         with Horizontal(id="main"):
             yield ProjectTree(id="tree-panel", state=self.state)
             with Vertical(id="right"):

--- a/cli/arcgispro_cli/tui/banner.py
+++ b/cli/arcgispro_cli/tui/banner.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+WIDE = r"""    _                 _     ____            ____ _     ___
+   / \   _ __ ___  __ _(_)___|  _ \ _ __ ___ / ___| |   |_ _|
+  / _ \ | '__/ __|/ _` | / __| |_) | '__/ _ \ |   | |    | |
+ / ___ \| | | (__| (_| | \__ \  __/| | | (_) | |___| |___ | |
+/_/   \_\_|  \___|\__, |_|___/_|   |_|  \___/ \____|_____|___|
+                  |___/"""
+
+COMPACT = "ArcGISPro CLI"
+TAGLINE = "Automate ArcGIS Pro from your terminal"
+
+
+class Banner(Widget):
+    """Top-of-screen banner with width-based fallback."""
+
+    DEFAULT_CSS = """
+    Banner { margin: 0 1; }
+    Banner > Static { color: $text; }
+    """
+
+    def __init__(self, *, enabled: bool = True, **kwargs):
+        super().__init__(**kwargs)
+        self.enabled = enabled
+        self._body = Static("")
+
+    def compose(self):
+        # Always mount, but render empty when disabled.
+        yield self._body
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def on_resize(self) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        if not self.enabled:
+            self._body.update("")
+            return
+
+        w = self.size.width or 0
+
+        # Choose a safe default for narrow terminals.
+        if w >= 80:
+            text = WIDE
+            # Add tagline if it won't obviously wrap.
+            if w >= 80:
+                text = text + "\n" + TAGLINE
+        elif w >= 40:
+            text = COMPACT + "\n" + TAGLINE
+        else:
+            text = COMPACT
+
+        self._body.update(text)


### PR DESCRIPTION
Implements issue #17.

- Adds a simple ASCII banner at the top of the Textual TUI.
- Picks wide vs compact vs minimal variant based on terminal width.
- Adds --no-banner flag to disable.

Notes:
- This keeps dependencies minimal (no figlet).