### PR TITLE
ci: enable pip caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: cli/pyproject.toml
 
       - name: Install package
         working-directory: cli
@@ -40,6 +42,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: cli/pyproject.toml
 
       - name: Install build tools
         run: pip install build


### PR DESCRIPTION
Enables pip caching in CI for faster runs.

No API changes.
